### PR TITLE
Use gtksink and autovideosrc instead of xvimagesink and v4l2src

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,12 +54,11 @@ Debian and Ubuntu dependencies
 
 This list of packages seems to make it work:
 
-    python  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-x python-cairo
+    python  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-cairo
 
 In Ubuntu, the package
-gstreamer1.0-x provides the xvimagesink element,
-gstreamer1.0-plugins-bad provides the zbar element, and
-gstreamer1.0-plugins-good provides the v4l2src element.
+gstreamer1.0-plugins-bad provides the zbar and the gtksink element, and
+gstreamer1.0-plugins-good provides the autovideosrc element.
 
 These packages should be optional:
 

--- a/keysign/scan_barcode.py
+++ b/keysign/scan_barcode.py
@@ -89,10 +89,9 @@ class BarcodeReaderGTK(Gtk.Box):
 
 
     def run(self):
-        p = "v4l2src \n"
-        ## FIXME: When using an image, the recorded frame is somewhat
-        ##        greenish.  I think we need to investigate that at some stage.
+        p = "autovideosrc  \n"
         #p = "uridecodebin uri=file:///tmp/qr.png "
+        #p = "uridecodebin uri=file:///tmp/v.webm "
         p += " ! tee name=t \n"
         p += "       t. ! queue ! videoconvert \n"
         p += "                  ! zbar cache=true attach_frame=true \n"


### PR DESCRIPTION
The gtksink helps us to remove code dealing with the X window IDs and more. It should also work much more reliably in virtual machines or with GL sinks.

The autovideosrc should work nicely with sandboxed environments like Flatpak.