### PR TITLE
Update the PKGBUILD for Arch Linux

### DIFF
--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,17 +1,25 @@
-# Maintainer: Profpatsch <mail AT [nickname] DOT de>
+# Maintainer: Ludovico de Nittis <aasonykk+aur at google mail dot com>
+# Contributor: Profpatsch <mail AT [nickname] DOT de>
+
 pkgname=gnome-keysign
-pkgver=0.7
+pkgver=0.8
 pkgrel=1
 pkgdesc="An easier way to sign OpenPGP keys over the local network."
 arch=('any')
-url="https://github.com/muelli/geysigning"
+url="https://github.com/gnome-keysign/gnome-keysign"
 license=('GPL3')
 depends=('python2' 'python2-requests' 'python2-gobject' 'python2-qrcode'
-         'avahi' 'dbus'
-         'monkeysign')
+         'avahi' 'dbus' 'monkeysign-git')
 makedepends=('python2-setuptools')
-source=(https://github.com/muelli/geysigning/releases/download/${pkgver}/gnome-keysign-${pkgver}.tar.gz)
-md5sums=('b5f66f50a734a7d95a4296d2f410a2e9')
+source=(https://github.com/gnome-keysign/gnome-keysign/archive/${pkgver}.tar.gz
+        "avoid_monkeysign.patch")
+sha256sums=('141bdb20a84a3b1fb5deb0fc52c5af0e02c601b2cc4923f89409b2a1b8509f88'
+            'c749fed5028b61c99292416f980decb23f9b90ce96eae05190aace764251575a')
+
+prepare() {
+    cd "${pkgname}-${pkgver}"
+    patch -Np1 -i "${srcdir}/avoid_monkeysign.patch"
+}
 
 build() {
     cd "${pkgname}-${pkgver}"

--- a/packaging/avoid_monkeysign.patch
+++ b/packaging/avoid_monkeysign.patch
@@ -1,0 +1,25 @@
+diff -ura gnome-keysign-0.8.orig/setup.py gnome-keysign-0.8.new/setup.py
+--- gnome-keysign-0.8.orig/setup.py	2017-03-11 12:07:21.394620381 +0100
++++ gnome-keysign-0.8.new/setup.py	2017-03-11 12:08:02.014620656 +0100
+@@ -27,14 +27,14 @@
+         'keysign.compat',
+         'keysign.network',
+         ],
+-    py_modules = [
+-        'monkeysign.msgfmt',
+-        'monkeysign.translation',
+-        'monkeysign.gpg',
+-    ],
++    #py_modules = [
++    #    'monkeysign.msgfmt',
++    #    'monkeysign.translation',
++    #    'monkeysign.gpg',
++    #],
+     package_dir={
+-        'keysign': 'keysign',
+-        'monkeysign': 'monkeysign/monkeysign'},
++        'keysign': 'keysign'},
++        #'monkeysign': 'monkeysign'},
+     #package_data={'keysign': ['data/*']},
+     data_files=[
+         ( 'share/applications',


### PR DESCRIPTION
The patch file avoid to install two times monkeysign because it is
already declared as dependency in the PKGBUILD.