### PR TITLE
app: Fix Gst.init parameters

### DIFF
--- a/keysign/app.py
+++ b/keysign/app.py
@@ -299,7 +299,7 @@ def main(args = []):
     log.debug('Running main with args: %s', args)
     if not args:
         args = []
-    Gst.init()
+    Gst.init(None)
 
     app = KeysignApp()
     try:

--- a/keysign/keyfprscan.py
+++ b/keysign/keyfprscan.py
@@ -94,7 +94,7 @@ class KeyFprScanWidget(Gtk.VBox):
         if not Gst.is_initialized():
             log.error("Gst does not seem to be initialised. Call Gst.init()!")
             # This needs to be called before creating a BarcodeReaderGTK
-            Gst.init()
+            Gst.init(None)
         reader = BarcodeReaderGTK()
         reader.set_size_request(150,150)
         reader.connect('barcode', self.on_barcode)
@@ -157,6 +157,6 @@ class KeyScanApp(Gtk.Application):
 if __name__ == "__main__":
     import sys
     logging.basicConfig(level=logging.DEBUG)
-    Gst.init()
+    Gst.init(None)
     app = KeyScanApp()
     app.run()

--- a/keysign/receive.py
+++ b/keysign/receive.py
@@ -181,7 +181,7 @@ def main(args=[]):
     log.debug('Running main with args: %s', args)
     if not args:
         args = []
-    Gst.init()
+    Gst.init(None)
 
     app = App()
     try:


### PR DESCRIPTION
Gst.init() requires a [str] or None as parameters.
On ArchLinux with the package gst-python that is "GStreamer Python
binding overrides (complementing the bindings provided by python-gi)",
leaving init() without parameters causes a runtime error.
Adding `None` as parameter it will works with gst-python and also
without it.