### PR TITLE
gnome-keysign-sign-key: Add encode() for Python 3 compatibility

### DIFF
--- a/keysign/gnome-keysign-sign-key.py
+++ b/keysign/gnome-keysign-sign-key.py
@@ -18,12 +18,12 @@
 
 import logging
 import sys
-from time import sleep
 
 from .util import sign_keydata_and_send
 
 if sys.version_info.major < 3:
     input = raw_input
+
 
 def main(args):
     log = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ def main(args):
     if not args:
         raise ValueError("You need to give filesnames as args: %s" % args)
     for fname in args:
-        data = open(fname, 'r').read()
+        data = open(fname, 'rb').read()
         log.info("Calling %r to sign %s", sign_keydata_and_send, fname)
         tmpfiles = list(sign_keydata_and_send(keydata=data))
     log.info("Finished signing. " +
@@ -39,6 +39,7 @@ def main(args):
              "files to be picked up. " +
              "Press any key to quit the application.")
     input()
+
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG,


### PR DESCRIPTION
encode() is necessary for Python 3 compatibility, otherwise it will
fail with:
"TypeError: arg 2: expected gpg.Data, file, bytes (not string!), or an
object implementing the buffer protocol. Got: str"

I also removed the unused sleep import.