### PR TITLE
locale/README.rst: improve new translation info

### DIFF
--- a/keysign/locale/README.rst
+++ b/keysign/locale/README.rst
@@ -49,7 +49,12 @@ Check the output of  locale -a  to determine which locales you have installed.
 Starting a new translation
 ---------------------------
 
-For providing a new language, the initial .po file can be created using:
+For providing a new language, first the .pot file has to be generated/updated using:
+
+    python setup.py extract_messages
+    
+Now, the initial .po file can be created using the below command,
+replacing "en" with the language code you want to translate to:
 
     python setup.py init_catalog --locale en
 


### PR DESCRIPTION
When a translator starts a new translation, chances are that no .pot file was generated yet. So, just make sure to generate a .pot file before running init_catalog.

Also, mention to replace "en" when generating the .po file to avoid having a translator starting translations for 'en' locale.