### PR TITLE
Spelling mistake corrected.

### DIFF
--- a/keysign/QRCode.py
+++ b/keysign/QRCode.py
@@ -112,7 +112,7 @@ class QRImage(Gtk.DrawingArea):
         background = self.background
         foreground = self.foreground
 
-        # This seems to set tje background,
+        # This seems to set the background,
         # but I'm not sure...
         cr.set_source_rgb(background, background, background)
         #cr.fill()


### PR DESCRIPTION
'tje' -> 'the'