### PR TITLE
Added twisted and zope.interface in the list of dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ so it should be easy for you to install it.
 If your version is older than that,
 this list of packages seems to make it work:
 
-    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-gi-cairo python-gpg
+    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-gi-cairo python-gpg twisted zope
 
 In Ubuntu, the package
 gstreamer1.0-plugins-bad provides the zbar and the gtksink element, and

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ so it should be easy for you to install it.
 If your version is older than that,
 this list of packages seems to make it work:
 
-    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-gi-cairo python-gpg twisted zope
+    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-gi-cairo python-gpg Twsited
 
 In Ubuntu, the package
 gstreamer1.0-plugins-bad provides the zbar and the gtksink element, and

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ so it should be easy for you to install it.
 If your version is older than that,
 this list of packages seems to make it work:
 
-    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-gi-cairo python-gpg Twsited
+    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python-gi-cairo python-gpg Twisted
 
 In Ubuntu, the package
 gstreamer1.0-plugins-bad provides the zbar and the gtksink element, and

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ The list of dependencies includes:
     * GStreamer with the good and bad plugins
     * GTK and Cairo
     * gobject introspection for those libraries
+    * Twisted( `pip install Twisted` )
     * PyBluez (optional)
 
 


### PR DESCRIPTION
Installing python-twisted through apt-get somehow throws an error of missing zope.interface. So using [pip](https://github.com/twisted/twisted/blob/trunk/INSTALL.rst#installation-requirements) is the [recommended](https://twistedmatrix.com/trac/wiki/Downloads#ThroughPip) way for installing twisted. 
Here's a link for similar error when installing python-twisted through apt-get. I don't know why apt-get misses zope.interface.  It is therefore recommended to use `pip install Twisted`.
[import error: No module named twisted.internet](https://stackoverflow.com/questions/17476761/importerror-no-module-named-twisted-internet)