### PR TITLE
util: fix TypeError when we try to sign with Bluetooth

### DIFF
--- a/keysign/util.py
+++ b/keysign/util.py
@@ -124,6 +124,11 @@ def sign_keydata_and_send(keydata, error_cb=None):
     # acceptable if all key operations are done before we go ahead
     # and spawn an email client.
     log.info("About to create signatures for key with fpr %r", fingerprint)
+    try:
+        keydata = keydata.encode()
+    except AttributeError:
+        log.debug("keydata is probably already a bytes type")
+
     for uid, encrypted_key in list(sign_keydata_and_encrypt(keydata, error_cb)):
             log.info("Using UID: %r", uid)
             # We expect uid.uid to be a consumable string


### PR DESCRIPTION
If we use Bluetooth as the transfer method the signing process will fail
with the following trace:

```
Traceback (most recent call last):
  File "/tmp/gnome-keysign/keysign/receive.py", line 155, in on_sign_key_confirmed
    sign_keydata_and_send(keydata))
  File "/tmp/gnome-keysign/keysign/util.py", line 127, in sign_keydata_and_send
    for uid, encrypted_key in list(sign_keydata_and_encrypt(keydata, error_cb)):
  File "/tmp/gnome-keysign/keysign/gpgmeh.py", line 406, in sign_keydata_and_encrypt
    ctx.op_import(minimise_key(keydata))
  File "/tmp/gnome-keysign/keysign/gpgmeh.py", line 380, in minimise_key
    ctx.op_import(keydata)
  File "/usr/lib/python2.7/site-packages/gpg/core.py", line 132, in _funcwrap
    result = func(slf.wrapped, *args)
TypeError: arg 2: expected gpg.Data, file, or an object implementing the buffer protocol, got unicode
```

To prevent this error we simply try to encode keydata before the import.

Thanks to @ZER-0-NE for reporting of this bug.