### PR TITLE
Gnome keysign patch#42 to fix Crash when invalid data has been downloaded

### DIFF
--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -39,8 +39,7 @@ class Discover:
             key_data = yield threads.deferToThread(self.discovery.find_key, self.userdata)
             log.debug("Received key successfully")
         except ValueError as e:
-            log.debug("foo", exc_info=e)
-            log.debug('Unable to get key_data, received malformed or altered key')
+            log.debug('Unable to get key_data, received malformed or altered key', exc_info=e)
             key_data = None
             success = False
             message = "Error downloading key, maybe it has been altered in transit"

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -38,9 +38,8 @@ class Discover:
         try:
             key_data = yield threads.deferToThread(self.discovery.find_key, self.userdata)
             log.debug("Received key successfully")
-        except ValueError:
-            exc_type, exc_value = exc_info()[:2]
-            log.debug('Handling %s exception with message "%s"', exc_type.__name__, exc_value)
+        except ValueError as e:
+            log.debug("Exception occured", exc_info=e)
             log.debug('Unable to get key_data, received malformed or altered key')
             key_data = None
             success = False

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -40,7 +40,10 @@ class Discover:
             log.debug("Received key successfully")
         except Exception as e:
             log.debug('Unable to get key_data, received malformed or altered key')
-            returnValue((None, False, ""))
+            key_data = None
+            success = False
+            message = ""
+            returnValue((key_data, success, message))
 
         if key_data and not self.stopped:
             success = True

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -1,5 +1,5 @@
 import logging
-
+from sys import exc_info
 from twisted.internet import threads
 from twisted.internet.defer import inlineCallbacks, returnValue
 
@@ -39,10 +39,12 @@ class Discover:
             key_data = yield threads.deferToThread(self.discovery.find_key, self.userdata)
             log.debug("Received key successfully")
         except ValueError:
+            exc_type, exc_value = exc_info()[:2]
+            log.debug('Handling %s exception with message "%s"', exc_type.__name__, exc_value)
             log.debug('Unable to get key_data, received malformed or altered key')
             key_data = None
             success = False
-            message = ""
+            message = "Error downloading key, maybe it has been altered in transit"
             returnValue((key_data, success, message))
 
         if key_data and not self.stopped:

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -39,7 +39,7 @@ class Discover:
             key_data = yield threads.deferToThread(self.discovery.find_key, self.userdata)
             log.debug("Received key successfully")
         except ValueError as e:
-            log.debug("Exception occured", exc_info=e)
+            log.debug("foo", exc_info=e)
             log.debug('Unable to get key_data, received malformed or altered key')
             key_data = None
             success = False

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -38,7 +38,7 @@ class Discover:
         try:
             key_data = yield threads.deferToThread(self.discovery.find_key, self.userdata)
             log.debug("Received key successfully")
-        except Exception as e:
+        except ValueError:
             log.debug('Unable to get key_data, received malformed or altered key')
             key_data = None
             success = False

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -29,25 +29,18 @@ class Discover:
         self.bt = None
         self.stopped = False
     
-    def success_callback(self, response):
-        #If the we find key with the given userdata, load the key
-        log.debug("key_data sucessfuly loaded")
-
-    def failure_callback(self, error):
-        #if we get an execption due to failure log the message
-        log.debug("malformed or altered key key received, loading keydata failed ")
-
     @inlineCallbacks
     def start(self):
         # First we try Avahi, if it fails we fallback to Bluetooth because
         # the receiver may be able to use only one of them
         log.info("Trying to use this code with Avahi: %s", self.userdata)
         
-        #chain callback to handle failure gracefully and prevent from crash
-        data = threads.deferToThread(self.discovery.find_key, self.userdata)
-        data.addCallback(self.success_callback)
-        data.addErrback(self.failure_callback)
-        key_data = yield data
+        try:
+            key_data = yield threads.deferToThread(self.discovery.find_key, self.userdata)
+            log.debug("Received key successfully")
+        except Exception as e:
+            log.debug('Unable to get key_data, received malformed or altered key')
+            returnValue((None, False, ""))
 
         if key_data and not self.stopped:
             success = True

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -1,5 +1,4 @@
 import logging
-from sys import exc_info
 from twisted.internet import threads
 from twisted.internet.defer import inlineCallbacks, returnValue
 


### PR DESCRIPTION
The crash was caused due to the unhandled failure. #42 

Failure in discover.py was causing "Unhandled error in Deferred",  chained addCallback() and addErrback() method to handle success and failure.
Also added success_callback and failure_callback  methods in Discover class to log debug messages and handle the successful result and failure response gracefully.


Working terminal log: (When proper key is retrieved)
```
keysign.gpgmks (DEBUG): Building cmd: 'gpg' '--command-fd' '0' '--with-fingerprint' '--list-options' 'show-sig-subpackets,show-uid-validity,show-unusable-uids,show-unusable-subkeys,show-keyring,show-sig-expire' '--status-fd' '2' '--quiet' '--batch' '--fixed-list-mode' '--no-tty' '--with-colons' '--use-agent' '--homedir' '/tmp/pygpg-z0OPCn' '--import'
keysign.gpgmks (DEBUG): Building cmd: 'gpg' '--command-fd' '0' '--with-fingerprint' '--list-options' 'show-sig-subpackets,show-uid-validity,show-unusable-uids,show-unusable-subkeys,show-keyring,show-sig-expire' '--status-fd' '2' '--quiet' '--batch' '--fixed-list-mode' '--no-tty' '--with-colons' '--use-agent' '--homedir' '/tmp/pygpg-z0OPCn' '--list-keys'
keysign.gpgkey (DEBUG): From mks: <OpenPGPkey(A573F587801EF013E711888FE774AAE681315880 UIDs:1)>
keysign.gpgkey (DEBUG): UidStr (37): 'suraj kadam <iamkadamsuraj@gmail.com>'
keysign.gpgkey (DEBUG): Parsing tokens: ['suraj kadam ', 'iamkadamsuraj@gmail.com>']
keysign.gpgkey (DEBUG): Parsed 'suraj kadam <iamkadamsuraj@gmail.com>' to name (11): u'suraj kadam'
keysign.util (INFO): MAC of '-----BEGIN PGP PUBLI' is 'F0518D3F634253ECE5A4'
keysign.util (INFO): MAC of '-----BEGIN PGP PUBLI' seems to be 'F0518D3F634253ECE5A4'. Expected 'F0518D3F634253ECE5A4' (True)
keysign.discover (DEBUG): key_data sucessfuly loaded
```

Working terminal log: (When malformed or altered  key is retrieved)

```
keysign.avahidiscovery (INFO): Trying to find key with 'OPENPGP4FPR:F98D03D7DC630399AAA6F43826B3F39189C397F6#MAC=A59CD97D53697DB2EFBA'
keysign.util (DEBUG): Parsed 'OPENPGP4FPR:F98D03D7DC630399AAA6F43826B3F39189C397F6#MAC=A59CD97D53697DB2EFBA' into ParseResult(scheme='openpgp4fpr', netloc='', path='F98D03D7DC630399AAA6F43826B3F39189C397F6', params='', query='', fragment='MAC=A59CD97D53697DB2EFBA')
keysign.util (DEBUG): Parsed barcode into {'MAC': ['A59CD97D53697DB2EFBA'], u'fingerprint': 'F98D03D7DC630399AAA6F43826B3F39189C397F6'}
keysign.util (WARNING): Cleaned fingerprint to F98D03D7DC630399AAA6F43826B3F39189C397F6
keysign.util (DEBUG): Starting HTTP request
urllib3.connectionpool (DEBUG): Starting new HTTP connection (1): 192.168.1.13
urllib3.connectionpool (DEBUG): http://192.168.1.13:9001 "GET / HTTP/1.1" 200 100
keysign.util (DEBUG): finished downloading 100 bytes
keysign.gpgmks (DEBUG): Building cmd: 'gpg' '--command-fd' '0' '--with-fingerprint' '--list-options' 'show-sig-subpackets,show-uid-validity,show-unusable-uids,show-unusable-subkeys,show-keyring,show-sig-expire' '--status-fd' '2' '--quiet' '--batch' '--fixed-list-mode' '--no-tty' '--with-colons' '--use-agent' '--homedir' '/tmp/pygpg-0GNKG_' '--import'
keysign.discover (DEBUG): malformed or altered key key received, loading keydata failed 
```


closes #42 