### PR TITLE
setup.py: open catalogs using UTF-8 in python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,10 @@ def get_catalogs(localedir):
     catalogs = {}
 
     for pofile in pofiles:
-        catalog = read_po(open(pofile, 'r'))
+        if sys.version_info.major > 2:
+            catalog = read_po(open(pofile, 'r', encoding='utf-8'))
+        else:
+            catalog = read_po(open(pofile, 'r'))
         catalogs[catalog.locale] = catalog
         logging.info("Found %d strings for %s", len(catalog), catalog.locale)
         # logging.debug("Strings for %r", catalog, catalog.values())


### PR DESCRIPTION
Otherwise they might be opened as ascii, leading to a UnicodeDecodeError.