### PR TITLE
Double appdata fixes

### DIFF
--- a/data/org.gnome.Keysign.raw.appdata.xml
+++ b/data/org.gnome.Keysign.raw.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>org.gnome.Keysign</id>
+  <id>org.gnome.Keysign.desktop</id>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Keysign</name>

--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,7 @@ setup(
     data_files=[
         ( 'share/applications',
             ['data/org.gnome.Keysign.desktop']),
-        ( 'share/appdata',
+        ( 'share/metainfo',
             ['data/org.gnome.Keysign.appdata.xml']),
         ( 'share/icons/hicolor/scalable/apps',
             ['data/org.gnome.Keysign.svg']),


### PR DESCRIPTION
This PR contains a fix for this issue https://github.com/hughsie/appstream-glib/issues/209#issuecomment-388020119 and, following the appstream specs, now the appdata file is stored inside `share/metainfo` instead of `share/appdata`