### PR TITLE
setup: update old pep8 to pycodestyle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ setup(
         "pgpy",
         "nose",
         "tox",
-        "pep8",
+        "pycodestyle",
         "pylint",
     ],
     license='GPLv3+',


### PR DESCRIPTION
The former pep8 has been recently renamed to pycodestyle.
https://github.com/PyCQA/pycodestyle/blob/82a2408c0c097d99d6ecfe13e876cdb77f37e112/README.rst