### PR TITLE
Allocate Bluetooth code with inlineCallbacks

### DIFF
--- a/keysign/offer.py
+++ b/keysign/offer.py
@@ -35,7 +35,7 @@ class Offer:
                 discovery_data.append(w_data)
         if BluetoothOffer:
             self.bt_offer = BluetoothOffer(self.key)
-            self.b_data = self.bt_offer.allocate_code()
+            self.b_data = yield self.bt_offer.allocate_code()
             if self.b_data:
                 discovery_data.append(self.b_data)
         discovery_data = ";".join(discovery_data)


### PR DESCRIPTION
This fix is related to the PR #52
Now we defer `get_local_bt_address` to a different thread. In this way
we don't stall the UI waiting for this method reply.