### PR TITLE
Replace python-avahi with a vendorized version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ so it should be easy for you to install it.
 If your version is older than that,
 this list of packages seems to make it work:
 
-    python  python-lxml  avahi-daemon  python-avahi python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-gtk3  python-gi-cairo python-gpg  python-twisted python-future
+    python  python-lxml  avahi-daemon  python-gi  gir1.2-glib-2.0   gir1.2-gtk-3.0 python-dbus    gir1.2-gstreamer-1.0 gir1.2-gst-plugins-base-1.0 gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-gtk3  python-gi-cairo python-gpg  python-twisted python-future
 
 Magic Wormhole can be installed with pip:
 
@@ -113,7 +113,7 @@ assuming that pip and git are already installed:
 
 .. code::
 
-    sudo dnf install -y python-lxml python-gobject python-avahi dbus-python gstreamer1-plugins-bad-free-gtk gstreamer1-plugins-good  gnupg python-gnupg  python-twisted
+    sudo dnf install -y python-lxml python-gobject dbus-python gstreamer1-plugins-bad-free-gtk gstreamer1-plugins-good  gnupg python-gnupg  python-twisted
     pip install magic-wormhole
 
 As optional:

--- a/keysign/network/AvahiBrowser.py
+++ b/keysign/network/AvahiBrowser.py
@@ -40,6 +40,33 @@ __all__ = ["AvahiBrowser"]
 
 DBusGMainLoop( set_as_default=True )
 
+# This should probably be upstreamed.
+# Unfortunately, upstream seems rather inactive.
+if getattr(avahi, 'txt_array_to_dict', None) is None:
+    # This has been taken from Gajim
+    # https://dev.gajim.org/gajim/gajim/blob/2d6e7d2e/gajim/common/zeroconf/zeroconf_avahi.py#L131
+    # it is licensed under the GPLv3.
+    # https://github.com/lathiat/avahi/pull/133
+    def txt_array_to_dict(txt_array):
+        txt_dict = {}
+        for els in txt_array:
+            key, val = '', None
+            for c in els:
+                c = chr(c)
+                if val is None:
+                    if c == '=':
+                        val = ''
+                    else:
+                        key += c
+                else:
+                    val += c
+            if val is None:  # missing '='
+                val = ''
+            txt_dict[key] = val
+        return txt_dict
+
+    setattr(avahi, 'txt_array_to_dict', txt_array_to_dict)
+
 
 class AvahiBrowser(GObject.GObject):
     __gsignals__ = {

--- a/keysign/network/AvahiBrowser.py
+++ b/keysign/network/AvahiBrowser.py
@@ -18,49 +18,27 @@
 #    You should have received a copy of the GNU General Public License
 #    along with GNOME Keysign.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
-import avahi, dbus
-from dbus import DBusException
-from dbus.mainloop.glib import DBusGMainLoop
+import logging
+import os
 
-from gi.repository import Gio
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import GObject
 
-import logging
+if __name__ == "__main__" and __package__ is None:
+    logging.getLogger().error("You seem to be trying to execute " +
+                              "this script directly which is discouraged. " +
+                              "Try python -m instead.")
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    os.sys.path.insert(0, parent_dir)
+    os.sys.path.insert(0, os.path.join(parent_dir, 'monkeysign'))
+    __package__ = str('keysign')
+
+from .AvahiConstants import AvahiConstants as avahi
 
 __all__ = ["AvahiBrowser"]
 
 DBusGMainLoop( set_as_default=True )
-
-# This should probably be upstreamed.
-# Unfortunately, upstream seems rather inactive.
-if getattr(avahi, 'txt_array_to_dict', None) is None:
-    # This has been taken from Gajim
-    # https://dev.gajim.org/gajim/gajim/blob/master/src/common/zeroconf/zeroconf_avahi.py
-    # it is licensed under the GPLv3.
-    # https://github.com/lathiat/avahi/pull/133
-    def txt_array_to_dict(txt_array):
-        txt_dict = {}
-        for els in txt_array:
-            key, val = '', None
-            for c in els:
-                    #FIXME: remove when outdated, this is for avahi < 0.6.14
-                    if c < 0 or c > 255:
-                        c = '.'
-                    else:
-                        c = chr(c)
-                    if val is None:
-                        if c == '=':
-                            val = ''
-                        else:
-                            key += c
-                    else:
-                        val += c
-            if val is None: # missing '='
-                val = ''
-            txt_dict[key] = val
-        return txt_dict
-
-    setattr(avahi, 'txt_array_to_dict', txt_array_to_dict)
 
 
 class AvahiBrowser(GObject.GObject):

--- a/keysign/network/AvahiConstants.py
+++ b/keysign/network/AvahiConstants.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#    Copyright 2018 Ludovico de Nittis <aasonykk+gnome@gmail.com>
+#
+#    This file is part of GNOME Keysign.
+#
+#    GNOME Keysign is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    GNOME Keysign is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with GNOME Keysign.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+import dbus
+
+if sys.version_info[0] >= 3:
+    unicode = str
+
+
+class AvahiConstants:
+    SERVER_RUNNING = 2
+    SERVER_COLLISION = 3
+
+    ENTRY_GROUP_ESTABLISHED = 2
+    ENTRY_GROUP_COLLISION = 3
+    ENTRY_GROUP_FAILURE = 4
+
+    PROTO_UNSPEC = -1
+
+    IF_UNSPEC = -1
+
+    LOOKUP_RESULT_LOCAL = 8
+
+    DBUS_NAME = "org.freedesktop.Avahi"
+    DBUS_INTERFACE_SERVER = DBUS_NAME + ".Server"
+    DBUS_PATH_SERVER = "/"
+    DBUS_INTERFACE_ENTRY_GROUP = DBUS_NAME + ".EntryGroup"
+    DBUS_INTERFACE_SERVICE_BROWSER = DBUS_NAME + ".ServiceBrowser"
+
+    @staticmethod
+    def txt_array_to_dict(txt_array):
+        # This has been taken from Gajim
+        # https://dev.gajim.org/gajim/gajim/blob/2d6e7d2e/gajim/common/zeroconf/zeroconf_avahi.py#L131
+        # it is licensed under the GPLv3.
+        # https://github.com/lathiat/avahi/pull/133
+        txt_dict = {}
+        for els in txt_array:
+            key, val = '', None
+            for c in els:
+                c = chr(c)
+                if val is None:
+                    if c == '=':
+                        val = ''
+                    else:
+                        key += c
+                else:
+                    val += c
+            if val is None:  # missing '='
+                val = ''
+            txt_dict[key] = val
+        return txt_dict
+
+    @staticmethod
+    def string_to_byte_array(s):
+        if isinstance(s, unicode):
+            s = s.encode('utf-8')
+
+        r = []
+
+        for c in s:
+            if isinstance(c, int):
+                # Python 3: iterating over bytes yields ints
+                r.append(dbus.Byte(c))
+            else:
+                # Python 2: iterating over str yields str
+                r.append(dbus.Byte(ord(c)))
+
+        return r
+
+    @staticmethod
+    def dict_to_txt_array(txt_dict):
+        l = []
+
+        for k, v in txt_dict.items():
+            if isinstance(k, unicode):
+                k = k.encode('utf-8')
+
+            if isinstance(v, unicode):
+                v = v.encode('utf-8')
+
+            l.append(AvahiConstants.string_to_byte_array(b"%s=%s" % (k, v)))
+
+        return l

--- a/keysign/network/AvahiConstants.py
+++ b/keysign/network/AvahiConstants.py
@@ -45,29 +45,6 @@ class AvahiConstants:
     DBUS_INTERFACE_SERVICE_BROWSER = DBUS_NAME + ".ServiceBrowser"
 
     @staticmethod
-    def txt_array_to_dict(txt_array):
-        # This has been taken from Gajim
-        # https://dev.gajim.org/gajim/gajim/blob/2d6e7d2e/gajim/common/zeroconf/zeroconf_avahi.py#L131
-        # it is licensed under the GPLv3.
-        # https://github.com/lathiat/avahi/pull/133
-        txt_dict = {}
-        for els in txt_array:
-            key, val = '', None
-            for c in els:
-                c = chr(c)
-                if val is None:
-                    if c == '=':
-                        val = ''
-                    else:
-                        key += c
-                else:
-                    val += c
-            if val is None:  # missing '='
-                val = ''
-            txt_dict[key] = val
-        return txt_dict
-
-    @staticmethod
     def string_to_byte_array(s):
         if isinstance(s, unicode):
             s = s.encode('utf-8')

--- a/keysign/network/AvahiPublisher.py
+++ b/keysign/network/AvahiPublisher.py
@@ -18,13 +18,23 @@
 #    You should have received a copy of the GNU General Public License
 #    along with GNOME Keysign.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+import os
 
-import avahi
 import dbus
 from dbus.mainloop.glib import DBusGMainLoop
 from gi.repository import GObject
 
-DBusGMainLoop( set_as_default=True )
+if __name__ == "__main__" and __package__ is None:
+    logging.getLogger().error("You seem to be trying to execute " +
+                              "this script directly which is discouraged. " +
+                              "Try python -m instead.")
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    os.sys.path.insert(0, parent_dir)
+    os.sys.path.insert(0, os.path.join(parent_dir, 'monkeysign'))
+    __package__ = str('keysign')
+
+from .AvahiConstants import AvahiConstants as avahi
+DBusGMainLoop(set_as_default=True)
 
 
 class AvahiPublisher:

--- a/packaging/gnome-keysign.spec
+++ b/packaging/gnome-keysign.spec
@@ -15,7 +15,7 @@ BuildRequires: python-lxml
 BuildRequires: python2-babel
 BuildRequires: /usr/bin/desktop-file-validate
 Requires:      python-gobject  gtk3
-Requires:      python-avahi  dbus-python
+Requires:      dbus-python
 Requires:      gstreamer1-plugins-bad-free-extras gstreamer1-plugins-good
 Requires:      python-qrcode
 Requires:      python-requests avahi-ui-tools


### PR DESCRIPTION
python-avahi is a package that just provides some constants. The problem
we were facing is that Debian is currently providing only python2-avahi
and not pytho3-avahi
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853239

With this commit we simply ship ourselves the Avahi constants we need,
like Gajim already did
https://dev.gajim.org/gajim/gajim/merge_requests/255

In AvahiBrowser there were also two unused imports (DBusException and
Gio), so I used this opportunity to remove them.