### PR TITLE
discover: fix error if discover was stopped

### DIFF
--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -88,7 +88,9 @@ class Discover:
         if self.stopped:
             key_data = None
             success = False
-            message = ""
+            # We use the LonelyError in a similar way as Wormhole does.
+            # That is to indicate that the connection as been stopped before a transfer.
+            message = LonelyError
 
         log.debug("Returning key: %r, success: %r, message: %r",
                   key_data, success, message)


### PR DESCRIPTION
If a user typed really fast in the receive tab, self.stopped was set at
True and the return of the "start()" function contained an empty
message.
Then in receive.py with "_receive()" the message was propagated reaching
the user interface as if an error occurred.

With this fix we return the LonelyError that is already gracefully
handled in "_receive()".
LonelyError fits this scenario because it indicates a connection stopped
before a transfer.