### PR TITLE
wormholeoffer: prevent unhandled LonelyError

### DIFF
--- a/keysign/wormholeoffer.py
+++ b/keysign/wormholeoffer.py
@@ -135,7 +135,7 @@ class WormholeOffer:
     def stop(self):
         if self.w:
             try:
-                self.w.close()
+                self.w.close().addErrback(log.debug)
             except (TransferError, ServerConnectionError, WrongPasswordError) as error:
                 # These errors should be already handled previously
                 # so here we can safely ignore them


### PR DESCRIPTION
With the recent wormhole versions (probably from the 0.11.0) the close()
behaviour slightly changed.
In keysign output we got this message when we cancelled a pending
sending operation:
```
Unhandled error in Deferred:

Traceback (most recent call last):
Failure: wormhole.errors.LonelyError:
```
To solve this I added an error callback to the close function. Because
we still catch every possible errors in the start() function, here I
just redirect the error output to `log.debug`.