### PR TITLE
provide pofiles in order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,9 +107,9 @@ def get_catalogs(localedir):
 
     # glob in Python 3.5 takes ** syntax
     # pofiles = glob.glob(os.path.join(localedir, '**.po', recursive=True))
-    pofiles = [os.path.join(dirpath, f)
+    pofiles = sorted([os.path.join(dirpath, f)
                for dirpath, dirnames, files in os.walk(localedir)
-               for f in files if f.endswith('.po')]
+               for f in files if f.endswith('.po')])
     logging.debug('Loading %r', pofiles)
     catalogs = {}
 


### PR DESCRIPTION
This is required to make the build reproducible since `os.walk()` delivers entries in non-specified order. (Upstreaming Debian patch https://salsa.debian.org/debian/gnome-keysign/commit/79552bfcb7880273b4b59c035bc42317c7c4e06f#725acc599c92eccc98708b484af46143e3bba690)