### PR TITLE
Produce an ephemeral local certification

### DIFF
--- a/keysign/app.py
+++ b/keysign/app.py
@@ -91,7 +91,13 @@ class PswMappingReceiveApp(ReceiveApp):
         psw.connect('map', self.func)
         if psw.get_mapped():
             self.func(psw)
-    
+
+    def get_toplevel(self):
+        """We're continuing to hack around
+        If we ever want to run a dialog, say a FileSave dialog, then we need to provide
+        the top level window of that widget.
+        """
+        return self.psw.get_toplevel()
 
 
 class KeysignApp(Gtk.Application):

--- a/keysign/gpgmeh.py
+++ b/keysign/gpgmeh.py
@@ -430,6 +430,8 @@ def local_sign_keydata(keydata, expires_in=60*60*24*1, error_cb=None, homedir=No
     the blue. But it can hardly be any worse than it is now.
     And the app ought to inform the user about the fact that it's only 
     ephemeral.
+
+    Returns: nothing
     """
     ctx = DirectoryContext(homedir)
 
@@ -448,6 +450,7 @@ def local_sign_keydata(keydata, expires_in=60*60*24*1, error_cb=None, homedir=No
         assert len(imports) == 1
         fpr = result.imports[0].fpr
 
+        ctx.op_import(keydata)
         key = ctx.get_key(fpr)
         # We need to sign in the regular context, because gpgme does not
         # export local signatures from a keyring.
@@ -455,6 +458,7 @@ def local_sign_keydata(keydata, expires_in=60*60*24*1, error_cb=None, homedir=No
         # Unfortunately, key_sign does not report back how many
         # signatures were produced (or not produced...)
         # It may raise an error, but I have yet to see that it does...
+        log.info("Locally signed key %s with an exiry in %d secods", fpr, expires_in)
 
 
 def sign_keydata_and_encrypt(keydata, error_cb=None, homedir=None):

--- a/keysign/gpgmeh.py
+++ b/keysign/gpgmeh.py
@@ -507,4 +507,4 @@ def sign_keydata_and_encrypt(keydata, error_cb=None, homedir=None):
                                                # in order for it to work out of the box
                                                always_trust=True,
                                                sign=False)
-                yield (UID.from_gpgme(uid), ciphertext)
+                yield (UID.from_gpgme(uid), ciphertext, uid_data)

--- a/keysign/keyconfirm.py
+++ b/keysign/keyconfirm.py
@@ -129,6 +129,15 @@ class PreSignWidget(Gtk.VBox):
         imagebox.add(ScalingImage(pixbuf=pixbuf))
         imagebox.show_all()
 
+        # We save the reference here to expose this infobar to the caller.
+        # This is a bit ugly, because it makes this implementation detail part of the
+        # API. The infobar should probably be part of the caller's responsibility,
+        # i.e. not part of this widget.
+        self.infobar_success = builder.get_object('infobar_certifications_produced')
+        self.infobar_save_as_button = builder.get_object('btn_local_import_save_as')
+        self.infobar_import_button = builder.get_object('btn_local_import')
+        self.infobar_help_button = builder.get_object('btn_local_import_help')
+
 
     def on_confirm_button_clicked(self, buttonObject, *args):
         self.emit('sign-key-confirmed', self.key, *args)

--- a/keysign/keyconfirm.py
+++ b/keysign/keyconfirm.py
@@ -136,7 +136,6 @@ class PreSignWidget(Gtk.VBox):
         self.infobar_success = builder.get_object('infobar_certifications_produced')
         self.infobar_save_as_button = builder.get_object('btn_local_import_save_as')
         self.infobar_import_button = builder.get_object('btn_local_import')
-        self.infobar_help_button = builder.get_object('btn_local_import_help')
 
 
     def on_confirm_button_clicked(self, buttonObject, *args):

--- a/keysign/receive.py
+++ b/keysign/receive.py
@@ -201,8 +201,11 @@ class ReceiveApp:
         self.log.debug ("Sign key confirmed! %r", key)
         # We need to prevent tmpfiles from going out of
         # scope too early so that they don't get deleted
-        self.tmpfiles = list(
-            sign_keydata_and_send(keydata))
+        tmpfiles_plaintext = list(sign_keydata_and_send(keydata))
+        self.log.debug("sign keydata result: %r", tmpfiles_plaintext)
+        # This is unzipping the list of tuples, e.g. [(1,2), (3,4)] becomes [(1,3), (2,4)]
+        self.tmpfiles, plaintexts = zip(*tmpfiles_plaintext)
+
 
         # After the user has signed, we switch back to the scanner,
         # because currently, there is not much to do on the

--- a/keysign/receive.ui
+++ b/keysign/receive.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkImage" id="confirm-button-image">
@@ -84,6 +84,9 @@ For more information visit &lt;a href="https://wiki.gnome.org/Apps/Keysign/Doc/N
             <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <object class="GtkBox" id="scanner_widget">
@@ -200,7 +203,7 @@ For more information visit &lt;a href="https://wiki.gnome.org/Apps/Keysign/Doc/N
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -325,6 +328,125 @@ For more information visit &lt;a href="https://wiki.gnome.org/Apps/Keysign/Doc/N
         <property name="margin_bottom">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
+        <child>
+          <object class="GtkInfoBar" id="infobar_certifications_produced">
+            <property name="can_focus">False</property>
+            <child internal-child="action_area">
+              <object class="GtkButtonBox">
+                <property name="can_focus">False</property>
+                <property name="spacing">6</property>
+                <property name="layout_style">end</property>
+                <child>
+                  <object class="GtkButton" id="btn_local_import_save_as">
+                    <property name="label">gtk-save-as</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Saves the produced certifications as separate files in a custom directory</property>
+                    <property name="use_stock">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_local_import">
+                    <property name="label">gtk-jump-to</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Imports a temporary version of the produced certifications into the local keyring</property>
+                    <property name="use_stock">True</property>
+                    <property name="always_show_image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_upload">
+                    <property name="label">gtk-go-up</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="no_show_all">True</property>
+                    <property name="use_stock">True</property>
+                    <property name="always_show_image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_local_import_help">
+                    <property name="label">gtk-help</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Opens the documentation for the local temporary signature feature</property>
+                    <property name="use_stock">True</property>
+                    <property name="image_position">right</property>
+                    <property name="always_show_image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child internal-child="content_area">
+              <object class="GtkBox">
+                <property name="can_focus">False</property>
+                <property name="spacing">16</property>
+                <child>
+                  <object class="GtkLabel" id="infobar_discover1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Successfully produced certifications.
+You can import a temporary signature to start using the key as if it had already been properly verified.</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
@@ -472,7 +594,7 @@ Alpha Bar &lt;example@example.com&gt;</property>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -533,16 +655,7 @@ Alpha Bar &lt;example@example.com&gt;</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkLabel" id="label20">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Signing the following UIDs:</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
+          <placeholder/>
         </child>
         <child>
           <object class="GtkLabel" id="uids_signed_label">
@@ -607,6 +720,18 @@ Alpha Bar &lt;example@example.com&gt;</property>
             <property name="fill">True</property>
             <property name="pack_type">end</property>
             <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label20">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Signing the following UIDs:</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>

--- a/keysign/receive.ui
+++ b/keysign/receive.ui
@@ -383,21 +383,7 @@ For more information visit &lt;a href="https://wiki.gnome.org/Apps/Keysign/Doc/N
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="btn_local_import_help">
-                    <property name="label">gtk-help</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Opens the documentation for the local temporary signature feature</property>
-                    <property name="use_stock">True</property>
-                    <property name="image_position">right</property>
-                    <property name="always_show_image">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -415,7 +401,8 @@ For more information visit &lt;a href="https://wiki.gnome.org/Apps/Keysign/Doc/N
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Successfully produced certifications.
-You can import a temporary signature to start using the key as if it had already been properly verified.</property>
+You can import a temporary signature to start using the key as if it had already been properly verified.
+For more information visit &lt;a href="https://wiki.gnome.org/Apps/Keysign/Doc/ProducedSignatures/1"&gt;the documentation&lt;/a&gt;.</property>
                     <property name="use_markup">True</property>
                   </object>
                   <packing>

--- a/keysign/util.py
+++ b/keysign/util.py
@@ -243,8 +243,9 @@ def sign_keydata_and_send(keydata, error_cb=None):
     For the resulting signatures, emails are created and
     sent via send_email.
     
-    Return value:  NamedTemporaryFiles used for saving the signatures.
-    If you let them go out of scope they should get deleted.
+    Return value:  A tuple of a
+    NamedTemporaryFiles used for saving the signatures and the plaintext which got encrypted.
+    If you let the TemporaryFiles go out of scope they should get deleted.
     But don't delete too early as the MUA needs to pick them up.
     """
     log = logging.getLogger(__name__ + ':sign_keydata')
@@ -291,7 +292,7 @@ def sign_keydata_and_send(keydata, error_cb=None):
         subject = Template(SUBJECT).safe_substitute(ctx)
         body = Template(body).safe_substitute(ctx)
         send_email(uid.email, subject, body, [filename])
-        yield tmpfile
+        yield tmpfile, plaintext
 
 
 def format_fingerprint(fpr):

--- a/keysign/util.py
+++ b/keysign/util.py
@@ -261,7 +261,7 @@ def sign_keydata_and_send(keydata, error_cb=None):
     except AttributeError:
         log.debug("keydata is probably already a bytes type")
 
-    for uid, encrypted_key in list(sign_keydata_and_encrypt(keydata, error_cb)):
+    for uid, encrypted_key, plaintext in list(sign_keydata_and_encrypt(keydata, error_cb)):
         log.info("Using UID: %r", uid)
         # We expect uid.uid to be a consumable string
         uid_str = uid.uid


### PR DESCRIPTION
This will hopefully make it easier to communicate with the person you have just met.
We make the certification expire within a day to limit the attack window.
We hope that the protocol will be completed until then so that the user does not notice the key not working any more.