### PR TITLE
util: Use brackets for IPv6 addresses, only

### DIFF
--- a/keysign/util.py
+++ b/keysign/util.py
@@ -359,16 +359,18 @@ def strip_fingerprint(input_string):
 
 
 def download_key_http(address, port):
+    netloc = "[%s]:%d" if ':' in address else "%s:%d"
     url = ParseResult(
         scheme='http',
         # This seems to work well enough with both IPv6 and IPv4
-        netloc="[[%s]]:%d" % (address, port),
+        netloc=netloc % (address, port),
         path='/',
         params='',
         query='',
         fragment='')
-    log.debug("Starting HTTP request")
-    data = requests.get(url.geturl(), timeout=5).content
+    u = url.geturl()
+    log.debug("Starting HTTP request for %s", u)
+    data = requests.get(u, timeout=5).content
     log.debug("finished downloading %d bytes", len(data))
     return data
 


### PR DESCRIPTION
With urllib3 newer than 1.22 it breaks:

urllib3.util.parse_url("http://[[127.1]]")
/tmp/gks3/lib/python3.6/site-packages/urllib3/util/url.py in
parse_url(url)
    399
    400     except (ValueError, AttributeError):
--> 401         return six.raise_from(LocationParseError(source_url),
None)
    402
    403     # For the sake of backwards compatibility we put empty

/tmp/gks3/lib/python3.6/site-packages/urllib3/packages/six.py in
raise_from(value, from_value)

LocationParseError: Failed to parse: http://[[127.1]]