### PR TITLE
Add a return certification button

### DIFF
--- a/keysign/keylistwidget.py
+++ b/keysign/keylistwidget.py
@@ -140,10 +140,18 @@ class KeyListWidget(Gtk.HBox):
         fix_infobar(self.ib_internet)
         self.label_ib_internet = builder.get_object('label_internet')
 
-        self.ib_import = builder.get_object('infobar_import')
-        fix_infobar(self.ib_import)
-        self.label_ib_import = builder.get_object('label_import')
-        self.image_ib_import = builder.get_object('image_import')
+        self.ib_import_okay = builder.get_object('infobar_import_okay')
+        self.ib_import_error = builder.get_object('infobar_import_error')
+        assert self.ib_import_okay
+        assert self.ib_import_error
+        fix_infobar(self.ib_import_okay)
+        fix_infobar(self.ib_import_error)
+        self.label_ib_import_okay = builder.get_object('label_import_okay')
+        self.image_ib_import_okay = builder.get_object('image_import_okay')
+        self.label_ib_import_error = builder.get_object('label_import_error')
+        self.image_ib_import_error = builder.get_object('image_import_error')
+        self.button_ib_import_error = builder.get_object('import_error_details_button')
+        self.button_ib_import_okay = builder.get_object('return_signature')
 
         if len(list(keys)) <= 0:
             infobar = builder.get_object("infobar")

--- a/keysign/send.py
+++ b/keysign/send.py
@@ -137,7 +137,7 @@ class SendApp:
             self.signature_imported()
         except errors.GPGMEError as e:
             log.exception("Could not import signatures")
-            self.signature_import_error()
+            self.signature_import_error(e)
 
     @inlineCallbacks
     def on_key_activated(self, widget, key):
@@ -215,16 +215,13 @@ class SendApp:
         log.info("No Internet connection")
 
     def signature_imported(self):
-        self.klw.image_ib_import.set_from_icon_name(Gtk.STOCK_OK, Gtk.IconSize.BUTTON)
-        self.klw.label_ib_import.set_label(_("The signature has been successfully imported!"))
-        self.klw.ib_import.show()
+        self.klw.ib_import_okay.show()
         log.info("Signature imported")
 
-    def signature_import_error(self):
-        self.klw.image_ib_import.set_from_icon_name(Gtk.STOCK_DIALOG_ERROR, Gtk.IconSize.BUTTON)
-        self.klw.label_ib_import.set_label(_("An error occurred while trying to import the signature.\n"
-                                           "Please double check the correctness of the chosen signature."))
-        self.klw.ib_import.show()
+    def signature_import_error(self, e):
+        self.klw.ib_import_error.show()
+        # We hide the error details button, because we don't have that functionality just yet
+        self.klw.button_ib_import_error.hide()
         log.info("Signature import error")
 
     def create_keypresent(self, discovery_code, discovery_data):

--- a/keysign/send.py
+++ b/keysign/send.py
@@ -216,6 +216,9 @@ class SendApp:
 
     def signature_imported(self):
         self.klw.ib_import_okay.show()
+        def return_certification(button):
+            log.info("Return certification")
+        self.klw.button_ib_import_okay.connect('clicked', return_certification)
         log.info("Signature imported")
 
     def signature_import_error(self, e):

--- a/keysign/send.ui
+++ b/keysign/send.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkApplicationWindow" id="appwindow">
@@ -236,7 +236,7 @@ Please use, e.g. Seahorse to create one.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkInfoBar" id="infobar_import">
+              <object class="GtkInfoBar" id="infobar_import_okay">
                 <property name="app_paintable">True</property>
                 <property name="can_focus">False</property>
                 <property name="no_show_all">True</property>
@@ -261,7 +261,7 @@ Please use, e.g. Seahorse to create one.</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">16</property>
                     <child>
-                      <object class="GtkLabel" id="label_import">
+                      <object class="GtkLabel" id="label_import_okay">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">The signature has been successfully imported!</property>
@@ -273,10 +273,114 @@ Please use, e.g. Seahorse to create one.</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkImage" id="image_import">
+                      <object class="GtkImage" id="image_import_okay">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="stock">gtk-dialog-ok</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="return_signature">
+                        <property name="label">gtk-undo</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Returns the received certification back to the sender, so that the sender can make use of your OpenPGP certificate</property>
+                        <property name="use_stock">True</property>
+                        <property name="always_show_image">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkInfoBar" id="infobar_import_error">
+                <property name="app_paintable">True</property>
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+                <property name="margin_bottom">5</property>
+                <property name="show_close_button">True</property>
+                <signal name="close" handler="on_ib_closed" swapped="no"/>
+                <signal name="response" handler="on_ib_closed" swapped="no"/>
+                <child internal-child="action_area">
+                  <object class="GtkButtonBox">
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <property name="layout_style">end</property>
+                    <child>
+                      <object class="GtkButton" id="import_error_details_button">
+                        <property name="label">gtk-info</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Display more details for the error.</property>
+                        <property name="use_stock">True</property>
+                        <property name="always_show_image">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child internal-child="content_area">
+                  <object class="GtkBox">
+                    <property name="can_focus">False</property>
+                    <property name="spacing">16</property>
+                    <child>
+                      <object class="GtkLabel" id="label_import_error">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">An error occurred while trying to import the signature.</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkImage" id="image_import_error">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="stock">gtk-dialog-error</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -301,7 +405,7 @@ Please use, e.g. Seahorse to create one.</property>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -396,7 +500,7 @@ Please use, e.g. Seahorse to create one.</property>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>

--- a/keysign/sign_and_encrypt.py
+++ b/keysign/sign_and_encrypt.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#    Copyright 2020 Tobias Mueller <tobi@cryptobit.ch>
+#
+#    This file is part of GNOME Keysign.
+#
+#    GNOME Keysign is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    GNOME Keysign is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with GNOME Keysign.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+
+import logging
+import sys
+
+from .gpgmeh import sign_keydata_and_encrypt, fingerprint_from_keydata
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Sign an OpenPGP key from a file. "
+        "The program will open each file, extract exactly one OpenPGP key, "
+        "sign each UID separately, encrypt and write the result out to a file.")
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+        help="Increase detail of logging")
+    parser.add_argument("file", nargs='+', type=argparse.FileType('rb'),
+        help="File containing OpenPGP keys")
+    args = parser.parse_args()
+
+    log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    log_level = log_levels[min(len(log_levels)-1, args.verbose)]
+    logging.basicConfig(level=log_level)
+
+    log = logging.getLogger(__name__)
+    log.debug('Running main with args: %s', args)
+
+    for fhandle in args.file:
+        data = fhandle.read()
+        fingerprint = fingerprint_from_keydata(data)
+        for i, (uid, ciphertext, plaintext) in enumerate(sign_keydata_and_encrypt(keydata=data)):
+            fname = "%s-%d.pgp" % (fingerprint, i)
+            with open(fname, 'wb') as outfile:
+                outfile.write(ciphertext)
+                print ("Written to %s \t for UID %s" % (fname, uid))
+
+
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG,
+            format='%(name)s (%(levelname)s): %(message)s')
+    sys.exit(main())

--- a/tests/create_attestee.sh
+++ b/tests/create_attestee.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+# A simple helper for creating an environment for the receiver of the newly produced certification
+
+ATTESTEE_DIR=/tmp/gks-attestee
+
+rm -rf "${ATTESTEE_DIR}.bak"
+mv -f "$ATTESTEE_DIR" "${ATTESTEE_DIR}.bak"
+mkdir -p $ATTESTEE_DIR
+echo -n | env GNUPGHOME=${ATTESTEE_DIR}  gpg --pinentry-mode loopback --batch --no-tty --yes --passphrase-fd 0 --quick-generate-key attestee@example.com
+env GNUPGHOME=${ATTESTEE_DIR}  gpg --armor --export attestee@example.com > ${ATTESTEE_DIR}/attestee.pgp.asc
+echo \"GNUPGHOME=${ATTESTEE_DIR}\"   python3 -m keysign.sign_and_encrypt  ${ATTESTEE_DIR}/attestee.pgp.asc

--- a/tests/create_attestor.sh
+++ b/tests/create_attestor.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+# A simple helper for creating an environment for the producer of a certification
+
+ATTESTOR_DIR=/tmp/gks-attestor
+
+rm -rf "${ATTESTOR_DIR}.bak"
+mv -f "$ATTESTOR_DIR" "${ATTESTOR_DIR}.bak"
+mkdir -p $ATTESTOR_DIR
+echo -n | env GNUPGHOME=${ATTESTOR_DIR}  gpg --pinentry-mode loopback --batch --no-tty --yes --passphrase-fd 0 --quick-generate-key attestor@example.com
+env GNUPGHOME=${ATTESTOR_DIR}  gpg --armor --export attestor@example.com > ${ATTESTOR_DIR}/attestor.pgp.asc
+
+echo env \"GNUPGHOME=${ATTESTOR_DIR}\" python3 -m keysign.sign_and_encrypt  ATTESTEE_DIR/attestee.pgp.asc


### PR DESCRIPTION
This lays the foundation for being able to return the signature we have received to where it has come from.
It doesn't work just yet, though.

The way I test this is to run the `create_attestee.sh` and attestor scripts, then `env "GNUPGHOME=/tmp/gks-attestor" python3 -m keysign.sign_and_encrypt /tmp/gks-attestee/attestee.pgp.asc`, and finally `env "GNUPGHOME=/tmp/gks-attestee" python3 -m keysign.send`. Then, I can drag and drop the generated file. After one run, I run `env "GNUPGHOME=/tmp/gks-attestee" gpg --edit-key atte` "minimize" "save" to have a clean state.