### PR TITLE
Fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Magic Wormhole can be installed with pip:
 In Ubuntu, the package
 gstreamer1.0-plugins-bad provides the zbar element and in versions older
 than 18.04 the gtksink element.
-In newer versions of Ubuntu, the gtksink elment is provided by the
+In newer versions of Ubuntu, the gtksink element is provided by the
 gstreamer1.0-gtk3 packages.
 gstreamer1.0-plugins-good provides the autovideosrc element.
 

--- a/keysign/KeyPresent.py
+++ b/keysign/KeyPresent.py
@@ -185,7 +185,7 @@ def parse_command_line(argv):
                         version="%(prog)s {}".format(__version__))
     parser.add_argument("-v", "--verbose", dest="verbose_count",
                         action="count", default=0,
-                        help="increases log verbosity for each occurence.")
+                        help="increases log verbosity for each occurrence.")
     #parser.add_argument("-g", "--gpg",
     #                    action="store_true", default=False,
     #                    help="Use local GnuPG Keyring instead of file.")

--- a/keysign/QRCode.py
+++ b/keysign/QRCode.py
@@ -113,7 +113,7 @@ class QRImage(Gtk.DrawingArea):
         background = self.background
         foreground = self.foreground
 
-        # This seems to set tje background,
+        # This seems to set the background,
         # but I'm not sure...
         cr.set_source_rgb(background, background, background)
         #cr.fill()

--- a/keysign/gpgmeh.py
+++ b/keysign/gpgmeh.py
@@ -145,7 +145,7 @@ def sign_key(uid=0, sign_cmd=u"sign", expire=False, check=3,
             status, prompt = yield 'Y'
         elif status == gpg.constants.STATUS_INV_SGNR:
             # seems to happen if you have an expired
-            # (or otherwise unsuable) signing key.
+            # (or otherwise unusable) signing key.
             # The CONSIDERED line should have been issued
             # with details.
             # We don't maintain that state at the moment which is
@@ -488,7 +488,7 @@ def local_sign_keydata(keydata, expires_in=60*60*24*1, error_cb=None, homedir=No
         # Unfortunately, key_sign does not report back how many
         # signatures were produced (or not produced...)
         # It may raise an error, but I have yet to see that it does...
-        log.info("Locally signed key %s with an exiry in %d secods", fpr, expires_in)
+        log.info("Locally signed key %s with an exiry in %d seconds", fpr, expires_in)
 
 
 def sign_keydata_and_encrypt(keydata, error_cb=None, homedir=None):

--- a/keysign/keyfprscan.py
+++ b/keysign/keyfprscan.py
@@ -60,7 +60,7 @@ class KeyFprScanWidget(Gtk.VBox):
                         (GObject.TYPE_PYOBJECT,)),
         # It's probably not the best name for that signal.
         # While "barcode_scanned" might be better, it is probably
-        # unneccesarily specific.
+        # unnecessarily specific.
         str('barcode'): (GObject.SignalFlags.RUN_LAST, None,
                         (str, # The barcode string
                          Gst.Message.__gtype__, # The GStreamer message itself
@@ -99,7 +99,7 @@ class KeyFprScanWidget(Gtk.VBox):
         reader.set_size_request(150,150)
         reader.connect('barcode', self.on_barcode)
         self.scanner.add(reader)
-        # We keep a referece here to not "lose" the object.
+        # We keep a reference here to not "lose" the object.
         # If we don't, Gtk crashes. With a segfault. Probably
         # because the object is freed but still used.
         # Somebody should look at that...

--- a/keysign/network/AvahiBrowser.py
+++ b/keysign/network/AvahiBrowser.py
@@ -145,7 +145,7 @@ class AvahiBrowser(GObject.GObject):
 def main():
     loop = GObject.MainLoop()
     # We're not passing the loop to DBus, because... well, it
-    # does't work... It seems to expect a DBusMainLoop, not
+    # doesn't work... It seems to expect a DBusMainLoop, not
     # an ordinary main loop...
     ab = AvahiBrowser()
 


### PR DESCRIPTION
Found via `codespell -S ./keysign/locale -L fpr,daa,ot`