### PR TITLE
Avoid SyntaxWarning with Python 3.12

### DIFF
--- a/keysign/app.py
+++ b/keysign/app.py
@@ -65,7 +65,7 @@ from . import gtkexcepthook
 log = logging.getLogger(__name__)
 
 def remove_whitespace(s):
-    cleaned = re.sub('[\s+]', '', s)
+    cleaned = re.sub(r'[\s+]', '', s)
     return cleaned
 
 


### PR DESCRIPTION
Python 3.12 warns about invalid escape sequences.

'[\s]+' contains an invalid escape sequence.  Python just treats it as a literal backslash followed by an s, but (for example) '[\n]+' would behave differently.

We fix this by telling python to treat the string as "raw" -- that is, not to escape the sequence at all.  This lets the regular expressions module see the backslash directly, as intended.