### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/keysign/bluetoothoffer.py
+++ b/keysign/bluetoothoffer.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     gtk3reactor.install()
     from twisted.internet import reactor
 from twisted.internet import threads
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 if sys.version < '3':
     input = raw_input
@@ -73,7 +73,7 @@ class BluetoothOffer:
             success = False
             message = e
 
-        returnValue((success, message))
+        return success, message
 
     @inlineCallbacks
     def allocate_code(self):
@@ -101,7 +101,7 @@ class BluetoothOffer:
             port = self.server_socket.getsockname()[1]
             log.info("BT Code: %s %s", code, port)
             bt_data = "BT={0};PT={1}".format(code, port)
-        returnValue(bt_data)
+        return bt_data
 
     def stop(self):
         log.debug("Stopping bt receive")

--- a/keysign/bluetoothreceive.py
+++ b/keysign/bluetoothreceive.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     gtk3reactor.install()
     from twisted.internet import reactor
 from twisted.internet import threads
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 if __name__ == "__main__" and __package__ is None:
     logging.getLogger().error("You seem to be trying to execute " +
@@ -94,16 +94,16 @@ class BluetoothReceive:
                 log.info("An unknown bt error occurred: %s" % be.args[0])
             key_data = None
             success = False
-            returnValue((key_data, success, be))
+            return key_data, success, be
         except Exception as e:
             log.error("An error occurred connecting or receiving: %s" % e)
             key_data = None
             success = False
-            returnValue((key_data, success, e))
+            return key_data, success, e
 
         if self.client_socket:
             self.client_socket.close()
-        returnValue((message.decode("utf-8"), success, None))
+        return message.decode("utf-8"), success, None
 
     def stop(self):
         self.stopped = True

--- a/keysign/discover.py
+++ b/keysign/discover.py
@@ -1,7 +1,7 @@
 import logging
 
 from twisted.internet import threads
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from wormhole.errors import LonelyError
 
 from .wormholereceive import WormholeReceive
@@ -94,7 +94,7 @@ class Discover:
 
         log.debug("Returning key: %r, success: %r, message: %r",
                   key_data, success, message)
-        returnValue((key_data, success, message))
+        return key_data, success, message
 
     def stop(self):
         self.stopped = True

--- a/keysign/offer.py
+++ b/keysign/offer.py
@@ -1,5 +1,5 @@
 import logging
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from .wormholeoffer import WormholeOffer
 from .avahioffer import AvahiHTTPOffer
@@ -40,7 +40,7 @@ class Offer:
         discovery_data = ";".join(discovery_data)
         # As design when we use both avahi and wormhole we only display
         # the wormhole code
-        returnValue((code, discovery_data))
+        return code, discovery_data
 
     def start(self):
         avahi_defers = self.a_offer.start()

--- a/keysign/wormholeoffer.py
+++ b/keysign/wormholeoffer.py
@@ -95,22 +95,23 @@ class WormholeOffer:
             log.info("Got data, %d bytes" % len(msg))
             success, error_msg = self._check_received(msg)
             self.stop()
-            return success, error_msg
 
         except (ServerConnectionError, WrongPasswordError) as e:
             error = dedent(e.__doc__)
             log.error("Error: %s" % error)
             success = False
-            return success, e
+            error_msg = e
         except LonelyError as le:
             log.info("Lonely, close() was called before the peer connection could be established")
             success = False
-            return success, le
+            error_msg = le
         except Exception as e:
             error = dedent(e.__doc__)
             log.error("An unknown error occurred: %s" % error)
             success = False
-            return success, e
+            error_msg = e
+
+        return success, error_msg
 
     def _check_received(self, msg):
         """If the received message has a field 'answer' that means that the transfer

--- a/keysign/wormholeoffer.py
+++ b/keysign/wormholeoffer.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     from twisted.internet import gtk3reactor
     gtk3reactor.install()
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 if __name__ == "__main__" and __package__ is None:
     logging.getLogger().error("You seem to be trying to execute " +
@@ -68,7 +68,7 @@ class WormholeOffer:
             code = yield self.w.get_code()
         log.info("Invitation Code: %s", code)
         wormhole_data = "WORM={0}".format(code)
-        returnValue((code, wormhole_data))
+        return code, wormhole_data
 
     @inlineCallbacks
     def start(self):
@@ -95,22 +95,22 @@ class WormholeOffer:
             log.info("Got data, %d bytes" % len(msg))
             success, error_msg = self._check_received(msg)
             self.stop()
-            returnValue((success, error_msg))
+            return success, error_msg
 
         except (ServerConnectionError, WrongPasswordError) as e:
             error = dedent(e.__doc__)
             log.error("Error: %s" % error)
             success = False
-            returnValue((success, e))
+            return success, e
         except LonelyError as le:
             log.info("Lonely, close() was called before the peer connection could be established")
             success = False
-            returnValue((success, le))
+            return success, le
         except Exception as e:
             error = dedent(e.__doc__)
             log.error("An unknown error occurred: %s" % error)
             success = False
-            returnValue((success, e))
+            return success, e
 
     def _check_received(self, msg):
         """If the received message has a field 'answer' that means that the transfer

--- a/keysign/wormholereceive.py
+++ b/keysign/wormholereceive.py
@@ -18,7 +18,7 @@
 
 import logging
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from wormhole.cli.public_relay import RENDEZVOUS_RELAY
 from wormhole.errors import WrongPasswordError, LonelyError, TransferError
 import wormhole
@@ -79,7 +79,7 @@ class WormholeReceive:
                     reply = {"answer": {"message_ack": "ok"}}
                     reply_encoded = encode_message(reply)
                     self.w.send_message(reply_encoded)
-                    returnValue((key_data.encode("utf-8"), success, message))
+                    return key_data.encode("utf-8"), success, message
                 else:
                     log.warning("The received key has a different MAC")
                     self._reply_error(_("Wrong message authentication code"))
@@ -121,7 +121,7 @@ class WormholeReceive:
     def _handle_failure(error):
         success = False
         key_data = None
-        returnValue((key_data, success, type(error)))
+        return key_data, success, type(error)
 
 
 def main(args):


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.