### PR TITLE
restore icons lost in GTK 4 UI migration

### DIFF
--- a/keysign/app4.ui
+++ b/keysign/app4.ui
@@ -24,6 +24,7 @@
               <object class="GtkBox">
                 <child>
                   <object class="GtkImage">
+                    <property name="icon-name">network-idle</property>
                     </object>
                 </child>
                 <child>

--- a/keysign/send4.ui
+++ b/keysign/send4.ui
@@ -49,6 +49,7 @@ Please use, e.g. Seahorse to create one.</property>
                         </child>
                         <child>
                           <object class="GtkImage">
+                            <property name="icon-name">dialog-error</property>
                             </object>
                         </child>
                         <child>
@@ -596,6 +597,7 @@ You can drag and drop the email here to import your certification.</property>
               <object class="GtkBox">
                 <child>
                   <object class="GtkImage">
+                    <property name="icon-name">network-idle</property>
                     </object>
                 </child>
                 <child>


### PR DESCRIPTION
The GTK 3 to GTK 4 UI file conversion dropped all `<property name="stock">` entries (GTK 4 removed stock items entirely) without replacing them with `<property name="icon-name">` equivalents, leaving empty `GtkImage` widgets that render no icon. This restores icons for the Internet toggle button, the error infobar and the connect button using freedesktop icon names.